### PR TITLE
configuration : globalAnnounceServer can be defined multiple (max 2) times

### DIFF
--- a/SyncthingTray/External/SyncThingConfig.xsd
+++ b/SyncthingTray/External/SyncThingConfig.xsd
@@ -31,7 +31,7 @@
           <xs:complexType>
             <xs:sequence>
               <xs:element type="xs:string" name="listenAddress"/>
-              <xs:element type="xs:string" name="globalAnnounceServer"/>
+              <xs:element type="xs:string" name="globalAnnounceServer" maxOccurs="2" />
               <xs:element type="xs:boolean" name="globalAnnounceEnabled"/>
               <xs:element type="xs:boolean" name="localAnnounceEnabled"/>
               <xs:element type="xs:int" name="localAnnouncePort"/>

--- a/SyncthingTray/External/SyncthingConfig.designer.cs
+++ b/SyncthingTray/External/SyncthingConfig.designer.cs
@@ -706,7 +706,7 @@ namespace SyncthingTray.External {
         
         private string listenAddressField;
         
-        private string globalAnnounceServerField;
+        private List<string> globalAnnounceServerField;
         
         private bool globalAnnounceEnabledField;
         
@@ -748,6 +748,10 @@ namespace SyncthingTray.External {
         
         private static System.Xml.Serialization.XmlSerializer serializer;
         
+        public configurationOptions() {
+            this.globalAnnounceServerField = new List<string>();
+        }
+        
         public string listenAddress {
             get {
                 return this.listenAddressField;
@@ -757,7 +761,7 @@ namespace SyncthingTray.External {
             }
         }
         
-        public string globalAnnounceServer {
+        public List<string> globalAnnounceServer {
             get {
                 return this.globalAnnounceServerField;
             }

--- a/SyncthingTray/External/SyncthingConfig.xml
+++ b/SyncthingTray/External/SyncthingConfig.xml
@@ -1,0 +1,36 @@
+﻿<configuration version="8">
+  <device id="V7HCVAK-V7HCVAK-V7HCVAK-KT4ICS5-KT4ICS5-KT4ICS5-KT4ICS5" name="stef" compression="true" introducer="false">
+    <address>dynamic</address>
+  </device>
+  <device id="RCVHQYS-RCVHQYS-RCVHQYS-RCVHQYS-VZPPVG3-VZPPVG3-VZPPVG3" name="pc" compression="false" introducer="false">
+    <address>dynamic</address>
+  </device>
+  <gui enabled="true" tls="false">
+    <address>127.0.0.1:8080</address>
+    <apikey>12340ghky16Wo7IktP2xpgsNiGPAabcd</apikey>
+  </gui>
+  <options>
+    <listenAddress>0.0.0.0:22000</listenAddress>
+    <globalAnnounceServer>udp4://announce.syncthing.net:22026</globalAnnounceServer>
+    <globalAnnounceServer>udp6://announce-v6.syncthing.net:22026</globalAnnounceServer>
+    <globalAnnounceEnabled>true</globalAnnounceEnabled>
+    <localAnnounceEnabled>true</localAnnounceEnabled>
+    <localAnnouncePort>21025</localAnnouncePort>
+    <localAnnounceMCAddr>[ff32::5222]:21026</localAnnounceMCAddr>
+    <maxSendKbps>0</maxSendKbps>
+    <maxRecvKbps>0</maxRecvKbps>
+    <reconnectionIntervalS>60</reconnectionIntervalS>
+    <startBrowser>false</startBrowser>
+    <upnpEnabled>true</upnpEnabled>
+    <upnpLeaseMinutes>0</upnpLeaseMinutes>
+    <upnpRenewalMinutes>30</upnpRenewalMinutes>
+    <urAccepted>-1</urAccepted>
+    <urUniqueID></urUniqueID>
+    <restartOnWakeup>true</restartOnWakeup>
+    <autoUpgradeIntervalH>12</autoUpgradeIntervalH>
+    <keepTemporariesH>24</keepTemporariesH>
+    <cacheIgnoredFiles>true</cacheIgnoredFiles>
+    <progressUpdateIntervalS>5</progressUpdateIntervalS>
+    <symlinksEnabled>true</symlinksEnabled>
+  </options>
+</configuration>

--- a/SyncthingTray/SyncthingTray.csproj
+++ b/SyncthingTray/SyncthingTray.csproj
@@ -148,9 +148,9 @@
       <DesignTime>True</DesignTime>
       <DependentUpon>strings.resx</DependentUpon>
     </Compile>
-    <Compile Include="External\SyncthingConfig.cs" >
-	<DependentUpon>SyncthingConfig.xsd</DependentUpon>
-	</Compile>
+    <Compile Include="External\SyncthingConfig.cs">
+      <DependentUpon>SyncthingConfig.xsd</DependentUpon>
+    </Compile>
     <Compile Include="SyncthingTray.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -199,6 +199,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="logo-64-grayscale.ico" />
+    <Content Include="External\SyncthingConfig.xml" />
     <Content Include="External\Xsd2Code.Addin.dll" />
     <Content Include="External\Xsd2Code.exe" />
     <Content Include="External\Xsd2Code.Library.Dll" />


### PR DESCRIPTION
In the configuration : globalAnnounceServer can be defined multiple (max 2) times. One for ipv4 and one for ipv6.

* The .xsd has been updated.
* Also added a example config.xml file.